### PR TITLE
Add support for dynamic imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -399,20 +399,40 @@
       "dev": true
     },
     "abstract-syntax-tree": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/abstract-syntax-tree/-/abstract-syntax-tree-2.7.0.tgz",
-      "integrity": "sha512-c12JhRqIQIkDEdO6riuWfplab3gOe0dPx17+XSpyyQcHpFV4S0BruHEeCFl0TcZQyU3m0KCV+Eut2nM2abGqtw==",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/abstract-syntax-tree/-/abstract-syntax-tree-2.8.5.tgz",
+      "integrity": "sha512-9cs0IQH3zvww5LVIcBhA7g/Q3DdZb4ndB8ChmJ1xdDikzFxs72Jf3IfbZzAnW2hQrb7t2ulMm4H8mn5Km21D7A==",
       "requires": {
-        "astring": "^1.3.0",
+        "astring": "^1.4.3",
         "asttv": "^1.0.1",
-        "esquery": "^1.0.1",
+        "esquery": "^1.3.1",
         "estemplate": "^0.5.1",
-        "estraverse": "^4.2.0",
-        "meriyah": "^1.9.1",
-        "source-map": "^0.7.2",
+        "estraverse": "^4.3.0",
+        "meriyah": "^1.9.15",
+        "source-map": "^0.7.3",
         "to-ast": "^1.0.0"
       },
       "dependencies": {
+        "esquery": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+          "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+          "requires": {
+            "estraverse": "^5.1.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+            }
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
@@ -1898,6 +1918,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
       }
@@ -3005,9 +3026,9 @@
       "dev": true
     },
     "meriyah": {
-      "version": "1.9.12",
-      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-1.9.12.tgz",
-      "integrity": "sha512-EgnwghBfzhegstEg3GL17cyjXs/YZOzDGW4mDpiv+v4ZqZgfjNvjfjsAJ99IJMA3LyGvdC8nffZJRGX65FOqLQ=="
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-1.9.15.tgz",
+      "integrity": "sha512-D4rT6XIYGqZab0EI/xbihUpwh0WbNRVQ35l2J/5QC2atxaI8h3KvA55DEJLBB/FRdaji7JwkNehfCRjCyjCjqw=="
     },
     "micromatch": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "standard": "^14.3.4"
   },
   "dependencies": {
-    "abstract-syntax-tree": "^2.7.0",
+    "abstract-syntax-tree": "^2.8.5",
     "pure-utilities": "^1.2.0",
     "underscore": "^1.10.2"
   },

--- a/src/class/Module.js
+++ b/src/class/Module.js
@@ -7,7 +7,7 @@ const { flatten } = require('pure-utilities/collection')
 
 class Module extends AbstractSyntaxTree {
   convert () {
-    if (this.has('ImportDeclaration')) {
+    if (this.has('ImportDeclaration') || this.has('ImportExpression')) {
       this.convertCodeWithImportDeclarations()
     } else if (this.has('ExportDefaultDeclaration')) {
       this.convertExportDefaultDeclarationToDefine()
@@ -18,6 +18,10 @@ class Module extends AbstractSyntaxTree {
 
   convertCodeWithImportDeclarations () {
     var pairs = this.getDependencyPairs()
+    if (this.has('ImportExpression')) {
+      pairs.unshift({ element: 'require', param: 'require' })
+      this.convertImportExpressions()
+    }
     this.remove({ type: 'ImportDeclaration' })
     this.normalizePairs(pairs)
     if (this.has('ExportDefaultDeclaration')) {
@@ -91,6 +95,20 @@ class Module extends AbstractSyntaxTree {
     }
   }
 
+  convertImportExpressions () {
+    this.replace(node => {
+      if (node.type !== 'ImportExpression') {
+        return node
+      }
+      var resolve = { type: 'Identifier', name: 'resolve' }
+      return this.getNewExpression('Promise', [
+        this.getFunctionExpression([resolve], [
+          this.getCallExpression('require', [this.getArrayExpression([node.source]), resolve])
+        ])
+      ])
+    })
+  }
+
   convertExportNamedDeclarations () {
     var declarations = this.find('ExportNamedDeclaration')
     this.convertExportNamedDeclarationToDeclaration()
@@ -162,6 +180,22 @@ class Module extends AbstractSyntaxTree {
         type: 'BlockStatement',
         body: body
       }
+    }
+  }
+
+  getNewExpression (name, args) {
+    return {
+      type: 'NewExpression',
+      callee: { type: 'Identifier', name: name },
+      arguments: args
+    }
+  }
+
+  getCallExpression (name, args) {
+    return {
+      type: 'CallExpression',
+      callee: { type: 'Identifier', name: name },
+      arguments: args
     }
   }
 

--- a/test/fixture/dynamic-import/input.js
+++ b/test/fixture/dynamic-import/input.js
@@ -1,0 +1,15 @@
+import Bar from 'Foo';
+
+import('foo.js').then(function(foo) {
+	console.log(foo);
+});
+
+import('bar' + '.js').then(function(bar) {
+	console.log(bar);
+});
+
+var dynamic = 'foobar';
+async function bar() {
+	var foo = await import(dynamic);
+	console.log(foo);
+}

--- a/test/fixture/dynamic-import/output.js
+++ b/test/fixture/dynamic-import/output.js
@@ -1,0 +1,20 @@
+define(["require", "Foo"], function (require, Bar) {
+    "use strict";
+    new Promise(function (resolve) {
+        require(["foo.js"], resolve)
+    }).then(function(foo) {
+        console.log(foo);
+    });
+    new Promise(function (resolve) {
+        require(["bar" + ".js"], resolve)
+    }).then(function (bar) {
+        console.log(bar);
+    });
+    var dynamic = "foobar";
+    async function bar() {
+        var foo = await new Promise(function (resolve) {
+            require([dynamic], resolve)
+        });
+        console.log(foo);
+    }
+});

--- a/test/spec/basic.js
+++ b/test/spec/basic.js
@@ -114,3 +114,7 @@ test('it works for default array export', t => {
 test('it works for named function expression', t => {
   t.truthy(convert('named-function-expression'))
 })
+
+test('it works for dynamic imports', t => {
+  t.truthy(convert('dynamic-import'))
+})


### PR DESCRIPTION
They are mapped to a promise that uses require()
in the background. Therefore "require" is added as dependency.

This PR raises abstract-syntax-tree dependnecy to at least 2.8 to
provide support for ImportExpression.

Also side-effect-middle test case is fixed, as that failed for me, due to another default ordering.