### PR TITLE
Add error handling for dynamic imports

### DIFF
--- a/src/class/Module.js
+++ b/src/class/Module.js
@@ -101,9 +101,10 @@ class Module extends AbstractSyntaxTree {
         return node
       }
       var resolve = { type: 'Identifier', name: 'resolve' }
+      var reject = { type: 'Identifier', name: 'reject' }
       return this.getNewExpression('Promise', [
-        this.getFunctionExpression([resolve], [
-          this.getCallExpression('require', [this.getArrayExpression([node.source]), resolve])
+        this.getFunctionExpression([resolve, reject], [
+          this.getCallExpression('require', [this.getArrayExpression([node.source]), resolve, reject])
         ])
       ])
     })

--- a/test/fixture/chained-dynamic-imports/output.js
+++ b/test/fixture/chained-dynamic-imports/output.js
@@ -2,21 +2,21 @@ define(["require"], function (require) {
     "use strict";
 
     Promise.all([
-        new Promise(function (resolve) {
-            require(["foo.js"], resolve)
+        new Promise(function (resolve, reject) {
+            require(["foo.js"], resolve, reject)
         }),
-        new Promise(function (resolve) {
-            require(["bar.js"], resolve)
+        new Promise(function (resolve, reject) {
+            require(["bar.js"], resolve, reject)
         })
     ]).then(values => {
         console.log(values);
     });
 
-    new Promise(function (resolve) {
-        require(["foo.js"], resolve)
+    new Promise(function (resolve, reject) {
+        require(["foo.js"], resolve, reject)
     }).then(() => {
-        return new Promise(function (resolve) {
-            require(["bar.js"], resolve)
+        return new Promise(function (resolve, reject) {
+            require(["bar.js"], resolve, reject)
         });
     });
 });

--- a/test/fixture/dynamic-import/output.js
+++ b/test/fixture/dynamic-import/output.js
@@ -1,19 +1,19 @@
 define(["require", "Foo"], function (require, Bar) {
     "use strict";
-    new Promise(function (resolve) {
-        require(["foo.js"], resolve)
+    new Promise(function (resolve, reject) {
+        require(["foo.js"], resolve, reject)
     }).then(function(foo) {
         console.log(foo);
     });
-    new Promise(function (resolve) {
-        require(["bar" + ".js"], resolve)
+    new Promise(function (resolve, reject) {
+        require(["bar" + ".js"], resolve, reject)
     }).then(function (bar) {
         console.log(bar);
     });
     var dynamic = "foobar";
     async function bar() {
-        var foo = await new Promise(function (resolve) {
-            require([dynamic], resolve)
+        var foo = await new Promise(function (resolve, reject) {
+            require([dynamic], resolve, reject)
         });
         console.log(foo);
     }


### PR DESCRIPTION
Reject promise for dynamic imports when require fails.

requirejs returns an Error subclass to the error handler.
therefore we can simply pass the value to the Promise reject()
method.