### PR TITLE
Provide wrapper for default exports in dynamic import()

### DIFF
--- a/test/fixture/chained-dynamic-imports/output.js
+++ b/test/fixture/chained-dynamic-imports/output.js
@@ -3,20 +3,20 @@ define(["require"], function (require) {
 
     Promise.all([
         new Promise(function (resolve, reject) {
-            require(["foo.js"], resolve, reject)
+            require(["foo.js"], function(module) { resolve(typeof module !== "object" || ("default" in module) ? {default: module} : Object.defineProperty(module, "default", {value: module, enumerable: false}) ) }, reject)
         }),
         new Promise(function (resolve, reject) {
-            require(["bar.js"], resolve, reject)
+            require(["bar.js"], function(module) { resolve(typeof module !== "object" || ("default" in module) ? {default: module} : Object.defineProperty(module, "default", {value: module, enumerable: false})) }, reject)
         })
     ]).then(values => {
         console.log(values);
     });
 
     new Promise(function (resolve, reject) {
-        require(["foo.js"], resolve, reject)
+        require(["foo.js"], function(module) { resolve(typeof module !== "object" || ("default" in module) ? {default: module} : Object.defineProperty(module, "default", {value: module, enumerable: false})) }, reject)
     }).then(() => {
         return new Promise(function (resolve, reject) {
-            require(["bar.js"], resolve, reject)
+            require(["bar.js"], function(module) { resolve(typeof module !== "object" || ("default" in module) ? {default: module} : Object.defineProperty(module, "default", {value: module, enumerable: false})) }, reject)
         });
     });
 });

--- a/test/fixture/dynamic-import/input.js
+++ b/test/fixture/dynamic-import/input.js
@@ -5,7 +5,7 @@ import('foo.js').then(function(foo) {
 });
 
 import('bar' + '.js').then(function(bar) {
-	console.log(bar);
+	console.log(bar.default);
 });
 
 var dynamic = 'foobar';

--- a/test/fixture/dynamic-import/output.js
+++ b/test/fixture/dynamic-import/output.js
@@ -1,19 +1,19 @@
 define(["require", "Foo"], function (require, Bar) {
     "use strict";
     new Promise(function (resolve, reject) {
-        require(["foo.js"], resolve, reject)
+        require(["foo.js"], function(module) { resolve(typeof module !== "object" || ("default" in module) ? {default: module} : Object.defineProperty(module, "default", {value: module, enumerable: false})) }, reject)
     }).then(function(foo) {
         console.log(foo);
     });
     new Promise(function (resolve, reject) {
-        require(["bar" + ".js"], resolve, reject)
+        require(["bar" + ".js"], function(module) { resolve(typeof module !== "object" || ("default" in module) ? {default: module} : Object.defineProperty(module, "default", {value: module, enumerable: false})) }, reject)
     }).then(function (bar) {
-        console.log(bar);
+        console.log(bar.default);
     });
     var dynamic = "foobar";
     async function bar() {
         var foo = await new Promise(function (resolve, reject) {
-            require([dynamic], resolve, reject)
+            require([dynamic], function(module) { resolve(typeof module !== "object" || ("default" in module) ? {default: module } : Object.defineProperty(module, "default", {value: module, enumerable: false})) }, reject)
         });
         console.log(foo);
     }


### PR DESCRIPTION
To write ES6 compatible code with the dyanmic import() syntax,
users need to fetch the `default` export using the `default` property of
the import()'s Promise return value.
Therefore we need to wrap the module into { default: module } in case it
returns the default export (this is in order to invert our conversion from
`export default foo` to `return foo` where we unwrap the "default"
property).

That means, we now wrap the AMD return value for dynamic imports into an
object expresion like `{ default: module }`, if the return value is not an
object, because it's 100% safe to assume that the export is the default
export in this case.

We add a non-enumerable self-referencing `default` property if the AMD
module returns an `object`. We can't be sure, what type of object
that is, it may be a) an object, exported as default export, or
b) an object that contains a list of named exports.

We therefore add the cyclic, non-enumerable default property that points
to the object itself, which allows the code to reference the default
export using the default property.

One exception is made: If the returned object already contains a default
property, we can assume that this is not a list of named exports, but rather
a default export (as we wouldn't generate an AMD module that contains both,
named and default exports, as named exports would be ignored)
We can therefore assume that the object is the default export wrap
it into a new object with a default property.

Example for a default export that contains a default property:

```
  # module 'foo'
  const data = {
    foo: 'bar',
    default: 'baz'
  }
  export default data;

  # other module
  import('foo').then(fooModule => {
    // Because of our wrapper, both, fooModule.foo and fooModule.default.foo would work,
    // but only fooModule.default.foo is ES6 compliant and would work when using the
    // ES6 module without conversion to an AMD module.
    console.log(fooModule.default.foo, fooModule.default.default)
  })
```